### PR TITLE
Add async series event emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,10 +447,12 @@
       }
     },
     "async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
-      "dev": true
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -1263,10 +1265,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -2096,6 +2097,12 @@
         "vm-browserify": "^1.1.2"
       },
       "dependencies": {
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -2116,8 +2123,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "homepage": "https://github.com/themost-framework/themost-client#readme",
   "dependencies": {
-    "@themost/xml": "^2.5.1"
+    "@themost/xml": "^2.5.1",
+    "async": "^2.6.4",
+    "events": "^3.2.0"
   },
   "devDependencies": {
     "@types/jasmine": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "MOST Web Framework 2.0 - Client Common Module",
   "module": "dist/themost-client.esm.js",
   "main": "dist/themost-client.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,9 @@ module.exports = [{
     ],
     external: [
         'url-parse',
-        '@themost/xml'
+        '@themost/xml',
+        'async',
+        'events'
     ],
     plugins: [
         typescript({

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,226 @@
+import * as EventEmitter from 'events';
+import { applyEachSeries } from 'async';
+
+declare interface FiredListener {
+    fired: boolean;
+}
+
+/**
+ * Wraps an async listener and returns a callback-like function
+ * @param {function(...*):Promise<void>} asyncListener
+ */
+function wrapAsyncListener(asyncListener: (...arg: any) => Promise<void>) {
+    /**
+     * @this AsyncSeriesEventEmitter
+     */
+    const result = function() {
+        // get arguments without callback
+        const args = [].concat(Array.prototype.slice.call(arguments, 0, arguments.length -1));
+        // get callback
+        const callback = arguments[arguments.length - 1];
+        return asyncListener.apply(this, args).then(() => {
+            return callback();
+        }).catch((err: Error) => {
+            return callback(err);
+        });
+    }
+    // set async listener property in order to have an option to unsubscribe
+    Object.defineProperty(result, '_listener', {
+        configurable: true,
+        enumerable: true,
+        value: asyncListener
+    });
+    return result;
+}
+
+function wrapOnceListener(listener: (...arg: any[]) => void) {
+    /**
+     * @this AsyncSeriesEventEmitter
+     */
+    const result = function() {
+        // get arguments without callback
+        const args = Array.from(arguments);
+        // get callback
+        const callback = args.pop();
+        args.push((err?: Error) => {
+            Object.assign(listener, {
+                fired: true
+            });
+            return callback(err);
+        });
+        return listener.apply(this, args);
+    }
+    // set async listener property in order to have an option to unsubscribe
+    Object.defineProperty(result, '_listener', {
+        configurable: true,
+        enumerable: true,
+        value: listener
+    });
+    return result;
+}
+
+/**
+ * Wraps an async listener and returns a callback-like function
+ * @param {string} event
+ * @param {function(...*):Promise<void>} asyncListener
+ */
+function wrapOnceAsyncListener(event: string | symbol, asyncListener: (...arg: any) => Promise<void>) {
+    /**
+     * @this AsyncSeriesEventEmitter
+     */
+    const result = function() {
+        // tslint:disable-next-line:no-arg
+        const callee = arguments.callee;
+        // get arguments without callback
+        const args = [].concat(Array.prototype.slice.call(arguments, 0, arguments.length -1));
+        // get callback
+        const callback = arguments[arguments.length - 1];
+        const self = this;
+        return asyncListener.apply(self, args).then(() => {
+            // manually remove async listener
+            self.removeListener(event, callee);
+            return callback();
+        }).catch((err: Error) => {
+            // manually remove async listener
+            self.removeListener(event, callee);
+            return callback(err);
+        });
+    }
+    // set async listener property in order to have an option to unsubscribe
+    Object.defineProperty(result, '_listener', {
+        configurable: true,
+        enumerable: true,
+        value: asyncListener
+    });
+    return result;
+}
+
+// noinspection JSClosureCompilerSyntax,JSClosureCompilerSyntax,JSClosureCompilerSyntax,JSClosureCompilerSyntax
+/**
+ * AsyncEventEmitter class is an extension of node.js EventEmitter class where listeners are executing in series.
+ */
+class AsyncSeriesEventEmitter extends EventEmitter {
+    constructor() {
+        super();
+    }
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     * Executes event listeners in series.
+     * @param {String} event - The event that is going to be executed.
+     * @param {...*} args - An object that contains the event arguments.
+     */
+    // eslint-disable-next-line no-unused-vars
+    emit(event: string | symbol, ...args: any[]): any {
+        // ensure callback
+        // get listeners
+        if (typeof this.listeners !== 'function') {
+            throw new Error('undefined listeners');
+        }
+        const listeners: any = this.listeners(event);
+
+        const argsAndCallback = [].concat(Array.prototype.slice.call(arguments, 1));
+        if (argsAndCallback.length > 0) {
+            // check the last argument (expected callback function)
+            if (typeof argsAndCallback[argsAndCallback.length - 1] !== 'function') {
+                throw new TypeError('Expected event callback');
+            }
+        }
+        // get callback function (the last argument of arguments list)
+        const callback = argsAndCallback.pop();
+
+        // validate listeners
+        if (listeners.length === 0) {
+            // exit emitter
+            return callback();
+        }
+        argsAndCallback.push((err?: Error) => {
+            for(const listener of listeners) {
+                if (listener._listener && listener._listener.fired) {
+                    this.removeListener(event, listener);
+                }
+            }
+            return callback(err);
+        });
+        // apply each series
+        return applyEachSeries.apply(this, [listeners].concat(argsAndCallback));
+    }
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     *
+     * @param {string} event
+     * @param {function(...*):Promise<void>} asyncListener
+     * @returns this
+     */
+    subscribe(event: string | symbol, asyncListener: (...args: any[]) => Promise<void>): this {
+        return this.on(event, wrapAsyncListener(asyncListener));
+    }
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     *
+     * @param {string} event
+     * @param {function(...*):Promise<void>} asyncListener
+     * @returns this
+     */
+    unsubscribe(event: string | symbol, asyncListener: (...args: any[]) => Promise<void>): this {
+        // get event listeners
+        const listeners = this.listeners(event);
+        // enumerate
+        // tslint:disable-next-line:prefer-for-of
+        for (let i = 0; i < listeners.length; i++) {
+            const item: any | { _listener: any} = listeners[i];
+            // if listener has an underlying listener
+            if (typeof item._listener === 'function') {
+                // and it's the same with the listener specified
+                if (item._listener === asyncListener) {
+                    // remove listener and break
+                    this.removeListener(event, item);
+                    break;
+                }
+            }
+        }
+        return this;
+    }
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     *
+     * @param {string} event
+     * @param {function(...*):Promise<void>} asyncListener
+     */
+    subscribeOnce(event: string | symbol, asyncListener: (...args: any[]) => Promise<void>): this {
+        return this.once(event,  wrapAsyncListener(asyncListener));
+    }
+    // noinspection JSUnusedGlobalSymbols
+    /**
+     *
+     * @param {string} event
+     * @param {...args} args
+     */
+    // eslint-disable-next-line no-unused-vars
+    next(event: string | symbol, ...args: any[]): Promise<void> {
+        const self = this;
+        /**
+         * get arguments as array
+         * @type {*[]}
+         */
+        const argsAndCallback: any[] = [event].concat(Array.prototype.slice.call(arguments, 1));
+        // eslint-disable-next-line no-undef
+        return new Promise((resolve, reject) => {
+            // set callback
+            argsAndCallback.push((err: Error) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve();
+            });
+            // emit event
+            self.emit.apply(self, argsAndCallback);
+        });
+    }
+    once(event: string | symbol, listener: (...args: any[]) => void): this {
+        return this.on(event, wrapOnceListener(listener));
+    }
+}
+
+export {
+    AsyncSeriesEventEmitter
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 export * from './common';
 export * from './client';
 export * from './metadata';
+export * from './events';

--- a/src/test/events.spec.ts
+++ b/src/test/events.spec.ts
@@ -1,0 +1,92 @@
+import {AsyncSeriesEventEmitter} from '../events';
+
+describe('AsyncSeriesEventEmitter', () => {
+
+    it('should create instance', ()=> {
+        const emitter = new AsyncSeriesEventEmitter();
+        expect(emitter).toBeTruthy();
+    });
+
+    it('should use AsyncSeriesEventEmitter.subscribe()', async ()=> {
+        const emitter = new AsyncSeriesEventEmitter();
+        emitter.subscribe('before.action', (event: { value: number }) => {
+            event.value += 1;
+            return Promise.resolve();
+        });
+        emitter.subscribe('before.action', (event: { value: number }) => {
+            event.value += 1;
+            return Promise.resolve();
+        });
+        const eventArgs = {
+            value: 100
+        }
+        await emitter.next('before.action', eventArgs);
+        expect(eventArgs.value).toBe(102);
+    });
+
+    it('should use AsyncSeriesEventEmitter.unsubscribe()', async ()=> {
+        const emitter = new AsyncSeriesEventEmitter();
+        const listener = (event: { value: number }) => {
+            event.value += 1;
+            return Promise.resolve();
+        }
+        emitter.subscribe('before.action', listener);
+        expect(emitter.listenerCount('before.action')).toBe(1);
+        emitter.unsubscribe('before.action', listener)
+        expect(emitter.listenerCount('before.action')).toBe(0);
+
+    });
+
+    it('should use AsyncSeriesEventEmitter.on()', async ()=> {
+        const emitter = new AsyncSeriesEventEmitter();
+        // tslint:disable-next-line:only-arrow-functions
+        emitter.on('before.action', function(ev, callback) {
+            ev.value += 2;
+            return callback();
+        });
+        // tslint:disable-next-line:only-arrow-functions
+        emitter.once('before.action', function(ev, callback) {
+            ev.value += 2;
+            return callback();
+        });
+        const eventArgs = {
+            value: 0
+        }
+        await new Promise<void>((resolve, reject) => {
+            // tslint:disable-next-line:only-arrow-functions
+            emitter.emit('before.action', eventArgs, function(err: Error) {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve();
+            });
+        });
+        let listenerCount = emitter.listenerCount('before.action');
+        expect(listenerCount).toBe(1);
+        expect(eventArgs.value).toBe(4);
+        emitter.removeAllListeners('before.action');
+        listenerCount = emitter.listenerCount('before.action');
+        expect(listenerCount).toBe(0);
+    });
+
+    it('should use AsyncSeriesEventEmitter.subscribeOnce()', async ()=> {
+        const emitter = new AsyncSeriesEventEmitter();
+        emitter.subscribe('before.action', async (event: { value: number }) => {
+            event.value += 2;
+        });
+        emitter.subscribeOnce('before.action', async (event: { value: number }) => {
+            event.value += 2;
+        });
+        const eventArgs = {
+            value: 0
+        }
+        await emitter.next('before.action', eventArgs);
+        expect(eventArgs.value).toBe(4);
+        const listenerCount = emitter.listeners('before.action').length;
+        expect(listenerCount).toBe(1);
+        await emitter.next('before.action', eventArgs);
+        expect(eventArgs.value).toBe(6);
+
+    });
+
+});

--- a/src/test/events.spec.ts
+++ b/src/test/events.spec.ts
@@ -2,91 +2,19 @@ import {AsyncSeriesEventEmitter} from '../events';
 
 describe('AsyncSeriesEventEmitter', () => {
 
-    it('should create instance', ()=> {
-        const emitter = new AsyncSeriesEventEmitter();
-        expect(emitter).toBeTruthy();
-    });
-
     it('should use AsyncSeriesEventEmitter.subscribe()', async ()=> {
-        const emitter = new AsyncSeriesEventEmitter();
-        emitter.subscribe('before.action', (event: { value: number }) => {
+        const emitter = new AsyncSeriesEventEmitter<{value: number}>();
+        emitter.subscribe(async (event: { value: number }) => {
             event.value += 1;
-            return Promise.resolve();
         });
-        emitter.subscribe('before.action', (event: { value: number }) => {
+        emitter.subscribe(async (event: { value: number }) => {
             event.value += 1;
-            return Promise.resolve();
         });
         const eventArgs = {
             value: 100
         }
-        await emitter.next('before.action', eventArgs);
+        await emitter.emit(eventArgs);
         expect(eventArgs.value).toBe(102);
-    });
-
-    it('should use AsyncSeriesEventEmitter.unsubscribe()', async ()=> {
-        const emitter = new AsyncSeriesEventEmitter();
-        const listener = (event: { value: number }) => {
-            event.value += 1;
-            return Promise.resolve();
-        }
-        emitter.subscribe('before.action', listener);
-        expect(emitter.listenerCount('before.action')).toBe(1);
-        emitter.unsubscribe('before.action', listener)
-        expect(emitter.listenerCount('before.action')).toBe(0);
-
-    });
-
-    it('should use AsyncSeriesEventEmitter.on()', async ()=> {
-        const emitter = new AsyncSeriesEventEmitter();
-        // tslint:disable-next-line:only-arrow-functions
-        emitter.on('before.action', function(ev, callback) {
-            ev.value += 2;
-            return callback();
-        });
-        // tslint:disable-next-line:only-arrow-functions
-        emitter.once('before.action', function(ev, callback) {
-            ev.value += 2;
-            return callback();
-        });
-        const eventArgs = {
-            value: 0
-        }
-        await new Promise<void>((resolve, reject) => {
-            // tslint:disable-next-line:only-arrow-functions
-            emitter.emit('before.action', eventArgs, function(err: Error) {
-                if (err) {
-                    return reject(err);
-                }
-                return resolve();
-            });
-        });
-        let listenerCount = emitter.listenerCount('before.action');
-        expect(listenerCount).toBe(1);
-        expect(eventArgs.value).toBe(4);
-        emitter.removeAllListeners('before.action');
-        listenerCount = emitter.listenerCount('before.action');
-        expect(listenerCount).toBe(0);
-    });
-
-    it('should use AsyncSeriesEventEmitter.subscribeOnce()', async ()=> {
-        const emitter = new AsyncSeriesEventEmitter();
-        emitter.subscribe('before.action', async (event: { value: number }) => {
-            event.value += 2;
-        });
-        emitter.subscribeOnce('before.action', async (event: { value: number }) => {
-            event.value += 2;
-        });
-        const eventArgs = {
-            value: 0
-        }
-        await emitter.next('before.action', eventArgs);
-        expect(eventArgs.value).toBe(4);
-        const listenerCount = emitter.listeners('before.action').length;
-        expect(listenerCount).toBe(1);
-        await emitter.next('before.action', eventArgs);
-        expect(eventArgs.value).toBe(6);
-
     });
 
 });

--- a/src/test/events.spec.ts
+++ b/src/test/events.spec.ts
@@ -3,18 +3,44 @@ import {AsyncSeriesEventEmitter} from '../events';
 describe('AsyncSeriesEventEmitter', () => {
 
     it('should use AsyncSeriesEventEmitter.subscribe()', async ()=> {
-        const emitter = new AsyncSeriesEventEmitter<{value: number}>();
-        emitter.subscribe(async (event: { value: number }) => {
+        class MyClass {
+            public readonly load = new AsyncSeriesEventEmitter<{value: number}>();
+        }
+        const item = new MyClass();
+        item.load.subscribe(async (event: { value: number }) => {
             event.value += 1;
         });
-        emitter.subscribe(async (event: { value: number }) => {
+        item.load.subscribe(async (event: { value: number }) => {
             event.value += 1;
         });
         const eventArgs = {
             value: 100
         }
-        await emitter.emit(eventArgs);
+        await item.load.emit(eventArgs);
         expect(eventArgs.value).toBe(102);
+    });
+
+    it('should use AsyncSeriesEventEmitter.subscribe() with timers', async ()=> {
+        class MyClass {
+            public readonly load = new AsyncSeriesEventEmitter<{status: string}>();
+        }
+        const item = new MyClass();
+        item.load.subscribe(async (event: { status: string }) => {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    event.status = 'active';
+                    resolve();
+                }, 1000);
+            });
+        });
+        item.load.subscribe(async (event: { status: string }) => {
+            event.status = 'unknown';
+        });
+        const eventArgs = {
+            status: null
+        }
+        await item.load.emit(eventArgs);
+        expect(eventArgs.status).toBe('unknown');
     });
 
 });


### PR DESCRIPTION
This PR add `AsyncSeriesEventEmitter` which is a sequential event emitter that is going to be used by client objects e.g.
```
const emitter = new AsyncSeriesEventEmitter();
emitter.subscribe('before.action', (event: { value: number }) => {
            event.value += 1;
            return Promise.resolve();
});
emitter.subscribe('before.action', (event: { value: number }) => {
            event.value += 1;
            return Promise.resolve();
});
const eventArgs = {
 value: 100
}
await emitter.next('before.action', eventArgs);
expect(eventArgs.value).toBe(102);
```
