### PR TITLE
add execute method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "MOST Web Framework 2.0 - Client Common Module",
   "module": "dist/themost-client.esm.js",
   "main": "dist/themost-client.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -759,6 +759,15 @@ export class ClientDataModel {
         });
     }
 
+    public execute(obj: any): Promise<any> {
+        return this.getService().execute({
+            method: 'POST',
+            url: this.getUrl(),
+            data: obj,
+            headers: {}
+        });
+    }
+
     public schema(): Promise<any> {
         return this.getService().execute({ method: 'GET',
             url: TextUtils.format('%s/schema.json', this.getName()),


### PR DESCRIPTION
This PR adds `ClientDataModel.execute(data)` method to support executing actions like `POST /Users/DisableUser` where `DisableUser` is an OData action of model `Users` and should be executed by posting a json object e.g.
```
{
   "user": 12300122
}
```
An equivalent code snippet may be:
```
await context.model('Users/DisableUser').execute(
  {
     "user": 12300122
  }
)
```