### PR TITLE
use tsconfig.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,6 @@ tsconfig.spec.json
 
 # tslint
 tslint.json
+
+# .gitpod
+.gitpod.yml

--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,7 @@ docs
 # test
 src/test
 spec
+src/test.ts
 
 # karma
 karma.conf.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/client",
-  "version": "2.9.6",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/client",
-      "version": "2.9.6",
+      "version": "2.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.9.6",
+  "version": "2.10.0",
   "description": "MOST Web Framework Codename Blueshift - Client Common",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ const name = 'index';
 const pkg = require('./package.json');
 
 module.exports = [{
-    input: './src/index.ts',
+    input: 'src/index.ts',
     output: [
         {
             file: `${dist}${name}.cjs.js`,
@@ -22,8 +22,6 @@ module.exports = [{
     ],
     external: Object.keys(pkg.dependencies),
     plugins: [
-        typescript({
-            declaration: true
-        })
+        typescript({ tsconfig: './tsconfig.json' })
     ]
 }];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "declaration": true,
-        "outDir": "./",
+        "outDir": "./dist",
         "stripInternal": true,
         "paths": {
         },
@@ -28,7 +28,6 @@
         "test"
     ],
     "files": [
-      "src/index.ts",
-      "src/common.ts"
+      "src/index.ts"
     ]
 }


### PR DESCRIPTION
This PR updates rollup configuration to use `tsconfig.json` in order to fix source map root.