### PR TITLE
use classes option to generate classes instead of interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/client",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "MOST Web Framework Codename Blueshift - Client Common",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/util/bin/cli.js
+++ b/util/bin/cli.js
@@ -13,6 +13,7 @@ async function main() {
         console.log('Usage: client-cli <source> [options]');
         console.log('Options:');
         console.log('  --out-file <output>  The output file to write the rendered types to');
+        console.log('  --classes Render classes instead of interfaces');
         return;
     }
     const source = args._[0];
@@ -21,7 +22,10 @@ async function main() {
         return process.exit(-1);
     }
     const isURL = source.startsWith('http://') || source.startsWith('https://');
-    const typeRenderer = isURL ? new TypeRenderer(source) : new FileSchemaRenderer(source);
+    const options = {
+        classes: args.classes
+    };
+    const typeRenderer = isURL ? new TypeRenderer(source, options) : new FileSchemaRenderer(source, options);
     const result = await typeRenderer.renderAny();
     if (args.outFile) {
         writeFileSync(args.outFile, result);

--- a/util/spec/TypeRenderer.spec.ts
+++ b/util/spec/TypeRenderer.spec.ts
@@ -22,6 +22,12 @@ describe("TypeRenderer", () => {
         expect(typeDeclarations).toBeInstanceOf(String);
     });
 
-
+    it("should render any type as class", async () => {
+        const renderer = new TypeRenderer('http://localhost:8080/api/', {
+            classes: true
+        });
+        const typeDeclarations = await renderer.renderAny();
+        expect(typeDeclarations).toBeInstanceOf(String);
+    });
 
 });


### PR DESCRIPTION
This PR enables the option of generating classes instead of interfaces.

```bash
npx @themost/client http://localhost:3000/api/ --classes --out-file entity.types.ts
```
will generate classes instead of interfaces

```typescript
import { EdmSchema } from '@themost/client';

@EdmSchema.entitySet('AccessLevelTypes')
export class AccessLevelType  {
	additionalType?: string;
	alternateName?: string;
	createdBy?: number;
	dateCreated?: Date;
	dateModified?: Date;
	description?: string;
	disambiguatingDescription?: string;
	id?: number;
	identifier?: string;
	image?: string;
	modifiedBy?: number;
	name?: string;
	sameAs?: string;
	url?: string;
}
```

